### PR TITLE
Minor fixups for Darwin

### DIFF
--- a/src/app/interprocesscommunicator.cpp
+++ b/src/app/interprocesscommunicator.cpp
@@ -1,5 +1,6 @@
 #include "app/interprocesscommunicator.h"
 #include <cstdlib>
+#include <cstring>
 #include <stdexcept>
 #include "helpers/stringhelpers.h"
 #ifndef _WIN32

--- a/src/filesystem/filesystemwatcher.cpp
+++ b/src/filesystem/filesystemwatcher.cpp
@@ -7,6 +7,17 @@
 #include <sys/inotify.h>
 #endif
 
+#ifdef __APPLE__
+#include <AvailabilityMacros.h>
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
+    // Only available in 10.7+
+    #define kFSEventStreamCreateFlagFileEvents 0x00000010
+    #define kFSEventStreamEventFlagItemCreated 0x00000100
+    #define kFSEventStreamEventFlagItemRemoved 0x00000200
+    #define kFSEventStreamEventFlagItemRenamed 0x00000800
+#endif
+#endif
+
 namespace Nickvision::Filesystem
 {
     FileSystemWatcher::FileSystemWatcher(const std::filesystem::path& path, bool incudeSubdirectories, WatcherFlags watcherFlags)

--- a/src/system/suspendinhibitor.cpp
+++ b/src/system/suspendinhibitor.cpp
@@ -3,6 +3,8 @@
 #include <windows.h>
 #elif defined(__linux__)
 #include <gio/gio.h>
+#elif defined(__APPLE__)
+#include <AvailabilityMacros.h>
 #endif
 
 namespace Nickvision::System
@@ -77,11 +79,15 @@ namespace Nickvision::System
         g_variant_unref(result);
         g_object_unref(proxy);
 #elif defined(__APPLE__)
+    #if MAC_OS_X_VERSION_MIN_REQUIRED > 1060
         IOReturn result{ IOPMAssertionCreateWithName(kIOPMAssertionTypePreventUserIdleSystemSleep, kIOPMAssertionLevelOn, CFSTR("Nickvision preventing suspend"), &m_cookie) };
         if(result != kIOReturnSuccess)
         {
             return false;
         }
+    #else
+        return false;
+    #endif
 #endif
         m_inhibiting = true;
         return true;


### PR DESCRIPTION
This addresses some build errors on macOS.

Values for `kFSEventStream*` are from 10.7 SDK; admittedly, I cannot say whether it gonna provide needed functionality, but at least this can be compiled, and a similar fix was used, for example, in this library: https://github.com/fsevents/fsevents/commit/d6141149037f6fefa3017fc45b9cd31bcacf155e

I am not sure if there is a functional fallback for `kIOPMAssertionTypePreventUserIdleSystemSleep`.