### PR TITLE
V2024.12.0-next

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           pkgs: boost-json curl gettext-libintl glib gtest libsecret maddy openssl
           triplet: x64-linux
-          revision: a54c4ba3aef5fe56cf11192f4476aaf057876551
+          revision: b322364f06308bdd24823f9d8f03fe0cc86fd46f
           token: ${{ secrets.GITHUB_TOKEN }}
           github-binarycache: true
       - name: "Build"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           pkgs: boost-json curl gettext-libintl glib gtest maddy openssl
           triplet: arm64-osx
-          revision: a54c4ba3aef5fe56cf11192f4476aaf057876551
+          revision: b322364f06308bdd24823f9d8f03fe0cc86fd46f
           token: ${{ secrets.GITHUB_TOKEN }}
           github-binarycache: true
       - name: "Build"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           pkgs: boost-json curl gettext-libintl gtest maddy sqlcipher
           triplet: x64-windows
-          revision: 3b57fb2e1ff55613db14d2aaf0a30529289c7050
+          revision: b322364f06308bdd24823f9d8f03fe0cc86fd46f
           token: ${{ secrets.GITHUB_TOKEN }}
           github-binarycache: true
       - name: "Build"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
-## 2024.12.0 (next)
+## 2024.12.0
 ### Breaking Changes
 None
 ### New APIs
 None
 ### Fixes
+#### Notifications
+- Fixed an issue where `ShellNotification::send()` did not work on non-GTK linux applications
 #### System
 - Fixed an issue where `Environment::getExecutableDirectory()` did not return the correct path on macOS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2024.12.0 (next)
+### Breaking Changes
+None
+### New APIs
+None
+### Fixes
+None
+
 ## 2024.11.1
 ### Breaking Changes
 None

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ None
 ### New APIs
 None
 ### Fixes
-None
+#### System
+- Fixed an issue where `Environment::getExecutableDirectory()` did not return the correct path on macOS
 
 ## 2024.11.1
 ### Breaking Changes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 
 #libnick Definition
-project ("libnick" LANGUAGES C CXX VERSION 2024.11.1 DESCRIPTION "A cross-platform base for native Nickvision applications.")
+project ("libnick" LANGUAGES C CXX VERSION 2024.12.0 DESCRIPTION "A cross-platform base for native Nickvision applications.")
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 include(CTest)

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = "libnick"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "2024.11.1"
+PROJECT_NUMBER         = "2024.12.0"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The above dependencies must be installed, *plus* the following for Linux systems
 ### macOS
 The above dependencies must be installed, *plus* the following for macOS systems:
 - glib
-- libsecret
+- libsecret (Only required if `-DUSE_LIBSECRET="ON"`)
 - openssl
     - Used for sqlcipher, as libnick manually builds sqlcipher on macOS as the vcpkg port is broken.
 
@@ -92,6 +92,7 @@ A C++20 compiler is also required to build libnick.
 #### macOS
 1. From the `build` folder, run `cmake .. -DCMAKE_BUILD_TYPE=Release`.
     - To skip building libnick's test suite, add `-DBUILD_TESTING="OFF"` to the end of the command.
+    - To use `libsecret` instead of macOS's built in security library, add `-DUSE_LIBSECRET="ON"` to the end of the command.
     - If you plan to install libnick, add `-DCMAKE_INSTALL_PREFIX=PATH_TO_INSTALL_DIR` to the end of the command, replacing `PATH_TO_INSTALL_DIR` with the path of where you'd like libnick to install to.
 1. From the `build` folder, run `cmake --build .`.
 1. After these commands complete, libnick will be successfully built and its binaries can be found in the `build` folder.

--- a/include/notifications/shellnotification.h
+++ b/include/notifications/shellnotification.h
@@ -42,8 +42,9 @@ namespace Nickvision::Notifications::ShellNotification
 #elif defined(__linux__)
     /**
      * @brief Sends a notification to the shell.
-     * @brief Uses Gio.Notification on Linux.
-     * @brief Supports the action "open" with action param being a path of a file or folder to open. The app must define an "app.open" action to handle this event.
+     * @brief Uses Gio.Notification on GTK applications.
+     * @brief Uses FreeDesktop Notifications on non-GTK applications.
+     * @brief Supports the action "open" with action param being a path of a file or folder to open. The app must define an "app.open" action to handle this event. (GTK applications only)
      * @param e ShellNotificationSentEventArgs
      * @param appId The application's id
      * @param openText Localized text of "Open"
@@ -52,7 +53,6 @@ namespace Nickvision::Notifications::ShellNotification
 #elif defined(__APPLE__)
     /**
      * @brief Sends a notification to the shell.
-     * @brief Uses NSUserNotification on macOS.
      * @param e ShellNotificationSentEventArgs
      */
     void send(const ShellNotificationSentEventArgs& e);

--- a/manual/README.md
+++ b/manual/README.md
@@ -12,7 +12,8 @@ None
 ### New APIs
 None
 ### Fixes
-None
+#### System
+- Fixed an issue where `Environment::getExecutableDirectory()` did not return the correct path on macOS
 
 ## Dependencies
 The following are a list of dependencies used by libnick. 

--- a/manual/README.md
+++ b/manual/README.md
@@ -6,12 +6,14 @@
 
 libnick provides Nickvision apps with a common set of cross-platform APIs for managing system and desktop app functionality such as network management, taskbar icons, translations, app updates, and more.
 
-## 2024.12.0 (next)
+## 2024.12.0
 ### Breaking Changes
 None
 ### New APIs
 None
 ### Fixes
+#### Notifications
+- Fixed an issue where `ShellNotification::send()` did not work on non-GTK linux applications
 #### System
 - Fixed an issue where `Environment::getExecutableDirectory()` did not return the correct path on macOS
 

--- a/manual/README.md
+++ b/manual/README.md
@@ -6,20 +6,20 @@
 
 libnick provides Nickvision apps with a common set of cross-platform APIs for managing system and desktop app functionality such as network management, taskbar icons, translations, app updates, and more.
 
-## 2024.11.1
+## 2024.12.0 (next)
 ### Breaking Changes
 None
 ### New APIs
 None
 ### Fixes
-- Fixed compilation issues for older macOS systems
+None
 
 ## Dependencies
 The following are a list of dependencies used by libnick. 
 
 ### All Platforms
+- boost-json
 - gtest
-- jsoncpp
 - libcurl
 - libintl
 - maddy
@@ -32,14 +32,13 @@ The above dependencies must be installed, *plus* the following for Windows syste
 The above dependencies must be installed, *plus* the following for Linux systems:
 - glib
 - libsecret
-- libuuid
 - openssl
     - Used for sqlcipher, as libnick manually builds sqlcipher on Linux as the vcpkg port is broken.
 
 ### macOS
 The above dependencies must be installed, *plus* the following for macOS systems:
 - glib
-- libsecret
+- libsecret (Only required if `-DUSE_LIBSECRET="ON"`)
 - openssl
     - Used for sqlcipher, as libnick manually builds sqlcipher on macOS as the vcpkg port is broken.
 
@@ -67,16 +66,16 @@ A C++20 compiler is also required to build libnick.
 1. Set the `VCPKG_ROOT` environment variable to the path of your vcpkg installation's root directory.
 #### Windows
 1. Set the `VCPKG_DEFAULT_TRIPLET` environment variable to `x64-windows`
-1. Run `vcpkg install curl gettext-libintl gtest jsoncpp maddy sqlcipher`
+1. Run `vcpkg install boost-json curl gettext-libintl gtest maddy sqlcipher`
 #### Linux
 1. Set the `VCPKG_DEFAULT_TRIPLET` environment variable to `x64-linux`
-1. Run `vcpkg install curl gettext-libintl glib gtest jsoncpp libsecret libuuid maddy openssl`
+1. Run `vcpkg install boost-json curl gettext-libintl glib gtest libsecret maddy openssl`
 #### macOS (Intel)
 1. Set the `VCPKG_DEFAULT_TRIPLET` environment variable to `x64-osx`
-1. Run `vcpkg install curl gettext-libintl glib gtest jsoncpp libsecret maddy openssl`
+1. Run `vcpkg install boost-json curl gettext-libintl glib gtest libsecret maddy openssl`
 #### macOS (Apple Silicon)
 1. Set the `VCPKG_DEFAULT_TRIPLET` environment variable to `arm64-osx`
-1. Run `vcpkg install curl gettext-libintl glib gtest jsoncpp libsecret maddy openssl`
+1. Run `vcpkg install boost-json curl gettext-libintl glib gtest libsecret maddy openssl`
 
 ### Building
 1. First, clone/download the repo.
@@ -97,6 +96,7 @@ A C++20 compiler is also required to build libnick.
 #### macOS
 1. From the `build` folder, run `cmake .. -DCMAKE_BUILD_TYPE=Release`.
     - To skip building libnick's test suite, add `-DBUILD_TESTING="OFF"` to the end of the command.
+    - To use `libsecret` instead of macOS's built in security library, add `-DUSE_LIBSECRET="ON"` to the end of the command.
     - If you plan to install libnick, add `-DCMAKE_INSTALL_PREFIX=PATH_TO_INSTALL_DIR` to the end of the command, replacing `PATH_TO_INSTALL_DIR` with the path of where you'd like libnick to install to.
 1. From the `build` folder, run `cmake --build .`.
 1. After these commands complete, libnick will be successfully built and its binaries can be found in the `build` folder.

--- a/src/system/environment.cpp
+++ b/src/system/environment.cpp
@@ -8,8 +8,8 @@
 #ifdef _WIN32
 #include <windows.h>
 #elif defined(__APPLE__)
-#include <libproc.h>
-#include <unistd.h>
+#include <mach-o/dyld.h>
+#include <sys/syslimits.h>
 #endif
 
 using namespace Nickvision::App;
@@ -47,11 +47,11 @@ namespace Nickvision::System
 #elif defined(__linux__)
         executableDirectory = std::filesystem::canonical("/proc/self/exe").parent_path();
 #elif defined(__APPLE__)
-        char pth[PROC_PIDPATHINFO_MAXSIZE];
-        int len{ proc_pidpath(getpid(), pth, sizeof(pth)) };
-        if(len > 0)
+        char path[PATH_MAX+1];
+        uint32_t size{ sizeof(path) };
+        if(_NSGetExecutablePath(path, &size) == 0)
         {
-            executableDirectory = std::filesystem::path(std::string(pth, len)).parent_path();
+            executableDirectory = std::filesystem::canonical(path).parent_path();
         }
 #endif
         return executableDirectory;


### PR DESCRIPTION
Fixes #53 

## TODO
- [x] #53 
- [x] `Environment::getExecutableDirectory()` not working on old macOS