### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "main" ]
     types: [ "review_requested", "ready_for_review" ]
 name: Spell Check
+permissions:
+  contents: read
 jobs:
   codespell:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/NickvisionApps/libnick/security/code-scanning/1](https://github.com/NickvisionApps/libnick/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Since the workflow uses `actions/checkout` and `codespell-project/actions-codespell`, it only needs read access to the repository contents. We will set `contents: read` in the `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
